### PR TITLE
Support for 16-bit and BI_BITFIELDS

### DIFF
--- a/ico4a/src/main/java/divstar/ico4a/codec/ico/ICODecoder.java
+++ b/ico4a/src/main/java/divstar/ico4a/codec/ico/ICODecoder.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Logger;
 
+import divstar.ico4a.codec.bmp.BMPConstants;
 import divstar.ico4a.codec.bmp.BMPDecoder;
 import divstar.ico4a.codec.bmp.ColorEntry;
 import divstar.ico4a.codec.bmp.InfoHeader;
@@ -181,6 +182,7 @@ public class ICODecoder {
 
                     andHeader.sBitCount = 1;
                     andHeader.iNumColors = 2;
+                    andHeader.iCompression = BMPConstants.BI_RGB;
 
                     // for now, just read all the raster data (img + and)
                     // and store as separate images

--- a/ico4a/src/main/java/divstar/ico4a/io/LittleEndianInputStream.java
+++ b/ico4a/src/main/java/divstar/ico4a/io/LittleEndianInputStream.java
@@ -51,7 +51,19 @@ public class LittleEndianInputStream extends java.io.DataInputStream implements 
 
     return (short) ((b2 << 8) + b1);
   }
-  
+
+	/**
+	 * Reads a little-endian <tt>unsigned short</tt> value
+	 * @throws IOException if an error occurs
+	 * @return <tt>unsigned short</tt> value with reversed byte order
+	 */
+	public int readUnsignedShortLE() throws IOException {
+		int i1 = readUnsignedByte();
+		int i2 = readUnsignedByte();
+
+		return (i2 << 8) | i1;
+	}
+
   /**
    * Reads a little-endian <tt>int</tt> value.
    * @throws IOException if an error occurs


### PR DESCRIPTION
Hello! I missed support for 16-bit and `BI_BITFIELDS` encodings so I tried to incorporate it myself. I am new to GitHub and contributing to open source projects, but I hope you find this useful. The methods have been tested, but unfortunately I am not at liberty to share the icon files I have tested with. There is a [test suite](http://entropymine.com/jason/bmpsuite/) for BMP files though, if you so require.

A summary of what I did:

- Add support for 16-bit `BI_RGB` encoding.

- Add support for 16-bit `BI_BITFIELDS` encoding.

- Add support for 32-bit `BI_BITFIELDS` encoding.

- Add support for reading 16-bit unsigned little-endan integers.

Please let me know what you think!